### PR TITLE
feat(middleware): Add errorHandler and .on('error') callback as error logger

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import bodyParser from 'koa-bodyparser';
 import cors from '@koa/cors';
 import routes from './src/routes/routes';
 import schemaValidator from '@middleware/validate';
+import errorHandler from '@middleware/errorHandler';
 import { port } from './config';
 
 const app = new Koa();
@@ -13,8 +14,12 @@ app.use(bodyParser())
     credentials: true
   }))
   .use(schemaValidator)
+  .use(errorHandler)
   .use(routes.routes())
-  .use(routes.allowedMethods());
+  .use(routes.allowedMethods())
+  .on('error', (err, ctx) => {
+    console.log(err);
+  });
 
 const server = app.listen(port, () => {
   console.log(`Server listening on port: ${port}`);

--- a/src/business/upsertSeries.business.ts
+++ b/src/business/upsertSeries.business.ts
@@ -87,6 +87,6 @@ export default async (ctx: Context) => {
       data: await upsertSeries(param)
     };
   } catch(err) {
-    return err;
+    ctx.throw(err);
   }
 };

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,0 +1,16 @@
+export default async (ctx, next) => {
+  try {
+    await next();
+  } catch (err) {
+    ctx.status = err.status || 500;
+    ctx.body = {
+      error: {
+        status: ctx.status,
+        type: err.name,
+        message: err.message,
+        details: err.details
+      }
+    }
+    ctx.app.emit('error', err, ctx);
+  }
+};

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -1,6 +1,8 @@
-export default async (ctx, next) => {
+import { Context, Next, Middleware } from "koa";
+
+export default async (ctx: Context, next: Next): Promise<Middleware> => {
   try {
-    await next();
+    return await next();
   } catch (err) {
     ctx.status = err.status || 500;
     ctx.body = {

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -11,14 +11,14 @@ export default async (ctx: Context, next: Next): Promise<Middleware> => {
   const { error, value } = Joi.validate(payload, schema);
 
   if (error) {
-    ctx.status = 400;
-    ctx.body = {
-      success: false,
-      message: error.message,
-      data: error.details[0]
-    };
-  } else {
-    ctx.request.body = value;
-    return await next();
+    ctx.assert(error.isJoi, 422, error.message);
+
+    ctx.throw(400, error.message.replace(/['"]/g, ''), { details: error.details.map(({message, type}) => ({
+      message: message.replace(/['"]/g, ''),
+      type
+    }))});
   }
+
+  ctx.request.body = value;
+  await next();
 }

--- a/src/services/alphaVantage.service.ts
+++ b/src/services/alphaVantage.service.ts
@@ -30,7 +30,7 @@ export default class AlphaVantageAPI {
 
       return await Promise.all(body);
     } catch(err) {
-      return err;
+      throw err;
     }
   }
 }


### PR DESCRIPTION
Method errorHandler as middleware. Include ctx.app.emit('error') to log sensitive application error information (stack trace) into a file, database, kibana or any other log service.
Start to use ctx.throw for formatted exceptions by http status code.

resolves #5 

references:
[koajs error-handling](https://github.com/koajs/koa/wiki/Error-Handling)
[4 Chapter - Handling errors in Koa](https://books.google.com.br/books?id=rwh-DwAAQBAJ&pg=PA49&dq=%224+handling+errors+in+KOA%22&hl=en&sa=X&ved=0ahUKEwjQuMuenMXoAhUGIbkGHQkTCNcQ6AEIKDAA#v=onepage&q=%224%20handling%20errors%20in%20KOA%22&f=false)
[node api schema validation with joi](https://www.digitalocean.com/community/tutorials/node-api-schema-validation-with-joi)
[toptal java error-handling](https://www.toptal.com/java/spring-boot-rest-api-error-handling)
[padronização de resposta de erro em APIs](https://medium.com/tableless/padroniza%C3%A7%C3%A3o-de-respostas-de-erro-em-apis-com-problem-details-23e58edf25ab)
[standardized response bodies (RFC 7807)](https://www.baeldung.com/rest-api-error-handling-best-practices#4-standardized-response-bodies)
[RF7807](https://blog.restcase.com/rest-api-error-handling-problem-details-response/)
(custom classes HttpException)[https://github.com/GoldL/island/blob/master/core/http-exception.js]
