### PR TITLE
feat(moment): Add dependency and change business date with .utc()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2870,6 +2870,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "mongodb": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.5.tgz",

--- a/package.json
+++ b/package.json
@@ -20,11 +20,12 @@
   "license": "ISC",
   "dependencies": {
     "@hapi/joi": "^15.1.1",
-    "koa": "^2.11.0",
     "@koa/cors": "^2.2.3",
+    "koa": "^2.11.0",
     "koa-bodyparser": "^4.2.1",
     "koa-jwt": "^3.6.0",
     "koa-router": "^7.4.0",
+    "moment": "^2.24.0",
     "mongodb": "^3.5.5",
     "soap": "^0.25.0",
     "xml2js": "^0.4.23"

--- a/src/business/getSeries.business.ts
+++ b/src/business/getSeries.business.ts
@@ -1,13 +1,13 @@
 import { getSeries } from "@data/query";
 import { Context } from "koa";
+import { utc } from 'moment';
 
 export default async (ctx: Context) => {
   const { idGroup, dateInitial, dateEnd } = ctx.request.body;
-  const [iYear, iMonth] = dateInitial.split("-");
   const params = {
     series: idGroup.map(_id => ( { _id } )),
     date: {
-      initial: new Date(`${iYear}-${iMonth}-01`).toISOString(),
+      initial: utc(dateInitial).startOf("month").toISOString(),
       end: new Date(dateEnd).toISOString()
     }
   };


### PR DESCRIPTION
Tried to use date-fns and encounter problems with utc date. Example:
```
startOfMonth(new Date('2011-05-31'), 1).toISOString() //"2011-05-01T00:00:00.000Z" OK
startOfMonth(new Date('2011-05-21'), 1).toISOString() //"2011-05-01T00:00:00.000Z" OK
startOfMonth(new Date('2011-05-01'), 1).toISOString() //"2011-04-01T00:00:00.000Z" NOK
```
This inconsistency, made follow @wagnerssouza suggestion to use moment. It's a bigger lib, but importing only the methods that will be used I belived isn't a burden on the app.

resolves #1 