### PR TITLE
refactor(schema/validate): Encapsulate schemas on route validate

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,7 @@ import Koa from 'koa';
 import bodyParser from 'koa-bodyparser';
 import cors from '@koa/cors';
 import routes from './src/routes/routes';
+import schemaValidator from '@middleware/validate';
 import { port } from './config';
 
 const app = new Koa();
@@ -11,6 +12,7 @@ app.use(bodyParser())
     allowHeaders: ['Origin', 'X-Requested-With', 'Content-Type', 'Accept'],
     credentials: true
   }))
+  .use(schemaValidator)
   .use(routes.routes())
   .use(routes.allowedMethods());
 

--- a/src/middleware/validate.ts
+++ b/src/middleware/validate.ts
@@ -1,9 +1,12 @@
 import Joi, { ObjectSchema } from "@hapi/joi";
+import { routeSchemas } from "@schema/series.schema";
 import { Context, Next, Middleware } from "koa";
 
 export default async (ctx: Context, next: Next): Promise<Middleware> => {
   const { query, method, body } = ctx.request;
   const payload = method === 'GET' ? query : body;
+  const schemas: Map<string, ObjectSchema> = new Map(routeSchemas[method.toLocaleLowerCase()]);
+  const schema = schemas.get(ctx.path);
 
   const { error, value } = Joi.validate(payload, schema);
 

--- a/src/routes/routes.ts
+++ b/src/routes/routes.ts
@@ -1,13 +1,19 @@
 import Router from 'koa-router';
 import getSeries from '@business/getSeries.business';
 import upsertSeries from '@business/upsertSeries.business';
-import { IGetSeries, IUpsertSeries } from "@schema/series.schema";
-import Validate from '@middleware/validate';
 import jwt from '@middleware/jwt';
 const routes = new Router();
 
-routes
-  .get('/series', Validate(IGetSeries), getSeries)
-  .post('/series',  Validate(IUpsertSeries), jwt, upsertSeries);
+routes.get('/series', async (ctx) => {
+  const data = await getSeries(ctx);
+  ctx.body = {
+    data: data
+  };
+}).post('/series', jwt, async (ctx) => {
+  const data = await upsertSeries(ctx);
+  ctx.body = {
+    data: data
+  };
+});
 
 export default routes;

--- a/src/schema/series.schema.ts
+++ b/src/schema/series.schema.ts
@@ -1,17 +1,23 @@
 import { object, array, ref, date, number, string, boolean } from "@hapi/joi";
 
-const IGetSeries = object({
-  idGroup: array().items(number()).single().unique().required(),
-  dateInitial: date().iso().max('now').required().raw(),
-  dateEnd: date().iso().max('now').min(ref('dateInitial')).required().raw()
-});
-const IUpsertSeries = object({
-  idGroup: array().items(number()).single().unique().required(),
-  date: object({
-    initial: date().iso().max('now').required().raw(),
-    end: date().iso().max('now').min(ref('initial')).required().raw()
-  })
-})
+const routeSchemas = {
+  get: [
+    ["/series", object({
+      idGroup: array().items(number()).single().unique().required(),
+      dateInitial: date().iso().max('now').required().raw(),
+      dateEnd: date().iso().max('now').min(ref('dateInitial')).required().raw()
+    })]
+  ],
+  post: [
+    ["/series", object({
+      idGroup: array().items(number()).single().unique().required(),
+      date: object({
+        initial: date().iso().max('now').required().raw(),
+        end: date().iso().max('now').min(ref('initial')).required().raw()
+      })
+    })]
+  ]
+};
 const IGetValoresSeriesJSONResponse = array().items(
   object({
     ID: number().required(),
@@ -26,7 +32,6 @@ const IGetValoresSeriesJSONResponse = array().items(
 ).single().unique().required();
 
 export {
-  IGetSeries,
-  IUpsertSeries,
+  routeSchemas,
   IGetValoresSeriesJSONResponse
 }


### PR DESCRIPTION
Now it is obligatory to create a schema for any route, because the validate
middleware start on the app index and verify body and queries