### PR TITLE
refactor(enums/upsertSeries): Add series and seriesAlpha enum

### DIFF
--- a/src/data/query.ts
+++ b/src/data/query.ts
@@ -26,7 +26,7 @@ const getSeries = async ({series, date: { initial, end }}) => {
   ]).toArray();
 }
 
-const upsertSeries = async ({items, date: { initial, end }}) => {
+const upsertSeries = async (items) => {
   const { client, db } = await Mongodb();
   const collection = db.collection('monthly_series');
   const serieUpdatePush = [].concat.apply([], items.map(item => {

--- a/src/enums/serie.enum.ts
+++ b/src/enums/serie.enum.ts
@@ -1,0 +1,19 @@
+enum Serie {
+    CDI = 4391,
+    IPCA = 433,
+    "IGP-M" = 189,
+    INCC = 192,
+    Ibovespa = 7832,
+    Ouro = 7830,
+    Poupança = 196,
+    SELIC = 4390,
+}
+
+enum SerieAlpha {
+    "^BVSP" = 7832
+}
+
+export {
+    Serie,
+    SerieAlpha
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
       "paths": {
         "@business/*": ["src/business/*"],
         "@data/*": ["src/data/*"],
+        "@enums/*": ["src/enums/*"],
         "@middleware/*": ["src/middleware/*"],
         "@routes/*": ["src/routes/*"],
         "@schema/*": ["src/schema/*"],


### PR DESCRIPTION
Enum supports reverse mapping which means we can access the value of a member and also a member name from its value.
This works for enum `[key: string]: number` not `[key: string]: string` and generate a extra code for lookup table.

resolves #2 