### PR TITLE
refactor(schemaValidator): Adjust route path name fetch method

### DIFF
--- a/src/middleware/schemaValidator.ts
+++ b/src/middleware/schemaValidator.ts
@@ -1,5 +1,4 @@
 import { ObjectSchema } from "@hapi/joi";
-import { Layer } from "@koa/router";
 import { routeSchemas } from "@schema/series.schema";
 import { Context, Next, Middleware } from "koa";
 
@@ -7,8 +6,7 @@ export default async (ctx: Context, next: Next): Promise<Middleware> => {
   const { query, method, body } = ctx.request;
   const payload = method === 'GET' ? query : body;
   const schemas: Map<string, ObjectSchema> = new Map(routeSchemas[method.toLocaleLowerCase()]);
-  const { path } = (ctx.matched as Layer[]).find(match => match.methods.includes(method)) || { path: undefined };
-  const schema = schemas.get(path);
+  const schema = schemas.get(ctx._matchedRoute);
 
   const { error, value } = schema.validate(payload);
 


### PR DESCRIPTION
Wrongly was making the code complex, because this middleware was being called
multiple times per request